### PR TITLE
Buffer output (aggressively)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ sonarqube {
     property "sonar.projectName", "data-extractor-job"
     property "sonar.projectKey", "data-extractor-job"
     property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml"
-    property 'sonar.coverage.exclusions', "**/uk.gov.hmcts.reform.dataextractor.Credentials*"
+    property 'sonar.coverage.exclusions', "**/uk.gov.hmcts.reform.dataextractor.Credentials.java"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ sonarqube {
     property "sonar.projectKey", "data-extractor-job"
     property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/jacoco/test.exec"
     property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/jacoco/integration.exec"
-
+    property 'sonar.coverage.exclusions', "**/uk/gov/hmcts/reform/dataextractor/**"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,7 @@ sonarqube {
   properties {
     property "sonar.projectName", "data-extractor-job"
     property "sonar.projectKey", "data-extractor-job"
-    property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/jacoco/test.exec"
-    property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/jacoco/integration.exec"
+    property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ sonarqube {
     property "sonar.projectName", "data-extractor-job"
     property "sonar.projectKey", "data-extractor-job"
     property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+    property 'sonar.coverage.exclusions', "**/uk.gov.hmcts.reform.dataextractor.Credentials*"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,6 @@ sonarqube {
     property "sonar.projectKey", "data-extractor-job"
     property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/jacoco/test.exec"
     property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/jacoco/integration.exec"
-    property 'sonar.coverage.exclusions', "**/uk/gov/hmcts/reform/dataextractor/**"
   }
 }
 

--- a/charts/data-extractor-job/values.yaml
+++ b/charts/data-extractor-job/values.yaml
@@ -1,6 +1,8 @@
 job:
   image: hmcts.azurecr.io/hmcts/data-extractor:latest
   schedule: "0 2 * * *"
+  memoryLimits: '2048Mi'
+  cpuLimits: '2000m'
 global:
   job:
     kind: CronJob

--- a/src/integrationTest/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriterTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.testcontainers.containers.GenericContainer;
@@ -65,15 +67,17 @@ public class BlobOutputWriterTest {
         blobStorageContainer.stop();
     }
 
-    @Test
-    public void whenfileUploaded_thenAvailableInBlobStorage() throws Exception {
-        String filePath = "dataA1.json";
+    @ParameterizedTest
+    @ValueSource(strings = {"dataA1.json", "dataA1.csv"})
+    public void whenfileUploaded_thenAvailableInBlobStorage(String filePath) throws Exception {
         try (BlobOutputWriter writer = new BlobOutputWriter(
             CLIENT_ID, ACCOUNT, CONTAINER, BLOB_PREFIX, DataExtractorApplication.Output.JSON_LINES)) {
             OutputStream outputStream = writer.outputStream(cloudBlobClient);
             assertNotNull(outputStream);
             InputStream inputStream = TestUtils.getStreamFromFile(filePath);
             IOUtils.copy(inputStream, outputStream);
+            outputStream.flush();
+            outputStream.close();
         }
         // retrieve uploaded blob
         CloudBlobContainer container = cloudBlobClient.getContainerReference(CONTAINER);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriterTest.java
@@ -167,15 +167,4 @@ public class BlobOutputWriterTest {
         });
     }
 
-    @Test
-    public void whenAadNotAvailable_thenCannotGetCredentialsInstance() throws Exception {
-        Assertions.assertThrows(WriterException.class, () -> {
-            try (BlobOutputWriter writer = new BlobOutputWriter(
-                    CLIENT_ID, "someotheraccount", CONTAINER,
-                    BLOB_PREFIX, DataExtractorApplication.Output.JSON_LINES)) {
-                writer.getCredentials();
-            }
-        });
-    }
-
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriterTest.java
@@ -20,6 +20,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
 import uk.gov.hmcts.reform.dataextractor.utils.TestUtils;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,6 +28,8 @@ import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.util.NoSuchElementException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -65,6 +68,15 @@ public class BlobOutputWriterTest {
     @AfterEach
     public void tearDown() {
         blobStorageContainer.stop();
+    }
+
+    @Test
+    public void whenBlobOutputWriterCreated_thenBufferedOutputAvailable() {
+        try (BlobOutputWriter writer = new BlobOutputWriter(
+                CLIENT_ID, ACCOUNT, CONTAINER, BLOB_PREFIX, DataExtractorApplication.Output.JSON_LINES)) {
+            OutputStream outputStream = writer.outputStream(cloudBlobClient);
+            assertThat(outputStream, instanceOf(BufferedOutputStream.class));
+        }
     }
 
     @ParameterizedTest

--- a/src/integrationTest/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLinesTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLinesTest.java
@@ -21,7 +21,7 @@ public class ExtractorJsonLinesTest extends DbTest {
              ResultSet resultSet = conn.createStatement()
                      .executeQuery("SELECT ID, NAME FROM parent WHERE ID IN (1, 2)")) {
 
-            ExtractorJson extractor = new ExtractorJsonLines();
+            ExtractorJsonLines extractor = new ExtractorJsonLines();
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             extractor.apply(resultSet, out);
             assertEquals("{\"id\":1,\"name\":\"A\"}\n{\"id\":2,\"name\":\"B\"}\n", out.toString());
@@ -36,7 +36,7 @@ public class ExtractorJsonLinesTest extends DbTest {
                      "SELECT P.ID, P.NAME, C.ID as \"child id\", C.DATA as data, C.NAME as \"child name\" "
                          + "FROM parent P JOIN child C on P.ID = C.PARENT_ID WHERE P.ID = 1")) {
 
-            ExtractorJson extractor = new ExtractorJsonLines();
+            ExtractorJsonLines extractor = new ExtractorJsonLines();
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             extractor.apply(resultSet, out);
             assertEquals(TestUtils.getDataFromFile("joinSelectQueryExpectedResult.json"), out.toString());

--- a/src/integrationTest/resources/dataA1.csv
+++ b/src/integrationTest/resources/dataA1.csv
@@ -1,0 +1,2 @@
+"lastName",firstName","address"
+"A1S","Harry","a1Address"

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriter.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -29,6 +30,7 @@ public class BlobOutputWriter implements AutoCloseable {
     private static final String STORAGE_RESOURCE = "https://storage.azure.com/";
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
     private static final String CONNECTION_URI_TPL = "https://%s.blob.core.windows.net";
+    private static final int OUTPUT_BUFFER_SIZE = 100_000_000;
 
     private final String clientId;
     private final String accountName;
@@ -99,7 +101,7 @@ public class BlobOutputWriter implements AutoCloseable {
             container = client.getContainerReference(this.containerName);
             CloudBlockBlob blob = container.getBlockBlobReference(fileName);
             blob.getProperties().setContentType(outputType.getApplicationContent());
-            outputStream = blob.openOutputStream();
+            outputStream = new BufferedOutputStream(blob.openOutputStream(), OUTPUT_BUFFER_SIZE);
         } catch (URISyntaxException | StorageException e) {
             throw new WriterException(e);
         }

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriter.java
@@ -1,9 +1,6 @@
 package uk.gov.hmcts.reform.dataextractor;
 
-import com.microsoft.azure.msiAuthTokenProvider.AzureMSICredentialException;
-import com.microsoft.azure.msiAuthTokenProvider.MSICredentials;
 import com.microsoft.azure.storage.StorageCredentials;
-import com.microsoft.azure.storage.StorageCredentialsToken;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
@@ -50,20 +47,6 @@ public class BlobOutputWriter implements AutoCloseable {
         this.outputType = outputType;
     }
 
-    protected StorageCredentials getCredentials() {
-        MSICredentials credsProvider = MSICredentials.getMSICredentials();
-        credsProvider.updateClientId(clientId);
-        try {
-            String accessToken = credsProvider.getToken(STORAGE_RESOURCE).accessToken();
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("Got access token: {}", accessToken != null ? accessToken.substring(0, 5) + "..." : "null");
-            }
-            return new StorageCredentialsToken(accountName, accessToken);
-        } catch (IOException | AzureMSICredentialException e) {
-            throw new WriterException(e);
-        }
-    }
-
     protected CloudBlobClient getClient() {
         URI connectionUri = null;
         try {
@@ -71,7 +54,7 @@ public class BlobOutputWriter implements AutoCloseable {
         } catch (URISyntaxException e) {
             throw new WriterException(e);
         }
-        StorageCredentials storageCredentials = getCredentials();
+        StorageCredentials storageCredentials = Credentials.get(clientId, STORAGE_RESOURCE, accountName);
         return new CloudBlobClient(connectionUri, storageCredentials);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/Credentials.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/Credentials.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.dataextractor;
+
+import com.microsoft.azure.msiAuthTokenProvider.AzureMSICredentialException;
+import com.microsoft.azure.msiAuthTokenProvider.MSICredentials;
+import com.microsoft.azure.storage.StorageCredentials;
+import com.microsoft.azure.storage.StorageCredentialsToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public final class Credentials {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Credentials.class);
+
+    private Credentials() {
+    }
+
+    public static StorageCredentials get(String clientId, String storageResource, String accountName) {
+        MSICredentials credsProvider = MSICredentials.getMSICredentials();
+        credsProvider.updateClientId(clientId);
+        try {
+            String accessToken = credsProvider.getToken(storageResource).accessToken();
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("Got access token: {}", accessToken != null ? accessToken.substring(0, 5) + "..." : "null");
+            }
+            return new StorageCredentialsToken(accountName, accessToken);
+        } catch (IOException | AzureMSICredentialException e) {
+            throw new WriterException(e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorCsv.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorCsv.java
@@ -14,10 +14,9 @@ public class ExtractorCsv implements Extractor {
 
     public void apply(ResultSet resultSet, OutputStream outputStream) {
         try (CSVPrinter printer =
-            new CSVPrinter(new PrintWriter(outputStream, true), CSVFormat.DEFAULT.withHeader(resultSet))
+            new CSVPrinter(new PrintWriter(outputStream, false), CSVFormat.DEFAULT.withHeader(resultSet))
         ) {
             printer.printRecords(resultSet);
-            printer.flush();
         } catch (IOException | SQLException e) {
             throw new ExtractorException(e);
         }

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.ResultSet;
@@ -14,35 +13,29 @@ import java.sql.SQLException;
 
 public class ExtractorJson implements Extractor {
 
-    OutputStream terminalOutputStream;
-
     public void apply(ResultSet resultSet, OutputStream outputStream) {
         final ObjectMapper objectMapper = new ObjectMapper();
-        try (ByteArrayOutputStream bufferedStream = new ByteArrayOutputStream(10_000_000);
-            JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(bufferedStream, JsonEncoding.UTF8)
+        try (JsonGenerator jsonGenerator = objectMapper.getFactory()
+            .configure(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM, false)
+            .createGenerator(outputStream, JsonEncoding.UTF8)
         ) {
-            this.terminalOutputStream = outputStream;
-            write(resultSet, jsonGenerator, bufferedStream);
+            write(resultSet, jsonGenerator);
         } catch (IOException | SQLException e) {
             throw new ExtractorException(e);
         }
     }
 
-    protected void write(ResultSet resultSet, JsonGenerator jsonGenerator, ByteArrayOutputStream bufferedStream)
+    protected void write(ResultSet resultSet, JsonGenerator jsonGenerator)
         throws SQLException, IOException {
         jsonGenerator.writeStartArray();
-        writeResultSetToJson(resultSet, jsonGenerator, bufferedStream);
+        writeResultSetToJson(resultSet, jsonGenerator);
         jsonGenerator.writeEndArray();
-        jsonGenerator.flush();
-        bufferedStream.writeTo(terminalOutputStream);
     }
 
-    protected void writeResultSetToJson(
-        ResultSet resultSet, JsonGenerator jsonGenerator, ByteArrayOutputStream bufferedStream)
+    protected void writeResultSetToJson(ResultSet resultSet, JsonGenerator jsonGenerator)
         throws SQLException, IOException {
         final ResultSetMetaData metaData = resultSet.getMetaData();
         final int columnCount = metaData.getColumnCount();
-        int iter = 0;
         while (resultSet.next()) {
             jsonGenerator.writeStartObject();
             for (int i = 1; i <= columnCount; i++) {
@@ -50,12 +43,6 @@ public class ExtractorJson implements Extractor {
                         metaData.getColumnTypeName(i));
             }
             writeEndObject(jsonGenerator);
-            iter++;
-            if (iter % 200 == 0) {
-                jsonGenerator.flush();
-                bufferedStream.writeTo(terminalOutputStream);
-                bufferedStream.reset();
-            }
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
@@ -15,10 +15,10 @@ public class ExtractorJson implements Extractor {
 
     public void apply(ResultSet resultSet, OutputStream outputStream) {
         final ObjectMapper objectMapper = new ObjectMapper();
-        try (JsonGenerator jsonGenerator = objectMapper.getFactory()
-            .configure(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM, false)
-            .createGenerator(outputStream, JsonEncoding.UTF8)
+        try (JsonGenerator jsonGenerator =
+            objectMapper.getFactory().createGenerator(outputStream, JsonEncoding.UTF8)
         ) {
+            jsonGenerator.disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
             write(resultSet, jsonGenerator);
         } catch (IOException | SQLException e) {
             throw new ExtractorException(e);

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
@@ -19,7 +19,6 @@ public class ExtractorJson implements Extractor {
             objectMapper.getFactory().createGenerator(outputStream, JsonEncoding.UTF8)
         ) {
             writeResultSetToJson(resultSet, jsonGenerator);
-            jsonGenerator.flush();
         } catch (IOException | SQLException e) {
             throw new ExtractorException(e);
         }

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
@@ -3,8 +3,8 @@ package uk.gov.hmcts.reform.dataextractor;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.ResultSet;
@@ -14,30 +14,35 @@ import java.sql.SQLException;
 
 public class ExtractorJson implements Extractor {
 
+    OutputStream terminalOutputStream;
+
     public void apply(ResultSet resultSet, OutputStream outputStream) {
         final ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(SerializationFeature.FLUSH_AFTER_WRITE_VALUE, false);
-        objectMapper.configure(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM, false);
-        try (JsonGenerator jsonGenerator =
-            objectMapper.getFactory().createGenerator(outputStream, JsonEncoding.UTF8)
+        try (ByteArrayOutputStream bufferedStream = new ByteArrayOutputStream(10_000_000);
+            JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(bufferedStream, JsonEncoding.UTF8)
         ) {
-            write(resultSet, jsonGenerator);
+            this.terminalOutputStream = outputStream;
+            write(resultSet, jsonGenerator, bufferedStream);
         } catch (IOException | SQLException e) {
             throw new ExtractorException(e);
         }
     }
 
-    protected void write(ResultSet resultSet, JsonGenerator jsonGenerator)
+    protected void write(ResultSet resultSet, JsonGenerator jsonGenerator, ByteArrayOutputStream bufferedStream)
         throws SQLException, IOException {
         jsonGenerator.writeStartArray();
-        writeResultSetToJson(resultSet, jsonGenerator);
+        writeResultSetToJson(resultSet, jsonGenerator, bufferedStream);
         jsonGenerator.writeEndArray();
+        jsonGenerator.flush();
+        bufferedStream.writeTo(terminalOutputStream);
     }
 
-    protected void writeResultSetToJson(ResultSet resultSet, JsonGenerator jsonGenerator)
+    protected void writeResultSetToJson(
+        ResultSet resultSet, JsonGenerator jsonGenerator, ByteArrayOutputStream bufferedStream)
         throws SQLException, IOException {
         final ResultSetMetaData metaData = resultSet.getMetaData();
         final int columnCount = metaData.getColumnCount();
+        int iter = 0;
         while (resultSet.next()) {
             jsonGenerator.writeStartObject();
             for (int i = 1; i <= columnCount; i++) {
@@ -45,6 +50,12 @@ public class ExtractorJson implements Extractor {
                         metaData.getColumnTypeName(i));
             }
             writeEndObject(jsonGenerator);
+            iter++;
+            if (iter % 200 == 0) {
+                jsonGenerator.flush();
+                bufferedStream.writeTo(terminalOutputStream);
+                bufferedStream.reset();
+            }
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.dataextractor;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.dataextractor;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -15,10 +17,11 @@ public class ExtractorJson implements Extractor {
 
     public void apply(ResultSet resultSet, OutputStream outputStream) {
         final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.FLUSH_AFTER_WRITE_VALUE, false);
+        objectMapper.configure(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM, false);
         try (JsonGenerator jsonGenerator =
             objectMapper.getFactory().createGenerator(outputStream, JsonEncoding.UTF8)
         ) {
-            jsonGenerator.disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
             write(resultSet, jsonGenerator);
         } catch (IOException | SQLException e) {
             throw new ExtractorException(e);

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLines.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLines.java
@@ -5,26 +5,20 @@ import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 
 import java.io.IOException;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
 
 public class ExtractorJsonLines extends ExtractorJson {
 
-    protected void writeResultSetToJson(ResultSet resultSet, JsonGenerator jsonGenerator)
+    protected void write(ResultSet resultSet, JsonGenerator jsonGenerator)
         throws SQLException, IOException {
-        final ResultSetMetaData metaData = resultSet.getMetaData();
-        final int columnCount = metaData.getColumnCount();
         jsonGenerator.setPrettyPrinter(new MinimalPrettyPrinter(""));
-        while (resultSet.next()) {
-            jsonGenerator.writeStartObject();
-            for (int i = 1; i <= columnCount; i++) {
-                writeRow(jsonGenerator, metaData.getColumnName(i), resultSet.getObject(i),
-                        metaData.getColumnTypeName(i));
-            }
-            jsonGenerator.writeEndObject();
-            jsonGenerator.writeRaw('\n');
-        }
+        writeResultSetToJson(resultSet, jsonGenerator);
+    }
+
+    protected void writeEndObject(JsonGenerator jsonGenerator) throws IOException {
+        jsonGenerator.writeEndObject();
+        jsonGenerator.writeRaw("\n");
     }
 
     protected void writeRow(JsonGenerator jsonGenerator, String columnName, Object data, String dataType)

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLines.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLines.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.dataextractor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -11,10 +12,12 @@ import java.sql.SQLException;
 public class ExtractorJsonLines extends ExtractorJson {
 
     @Override
-    protected void write(ResultSet resultSet, JsonGenerator jsonGenerator)
+    protected void write(ResultSet resultSet, JsonGenerator jsonGenerator, ByteArrayOutputStream bufferedStream)
         throws SQLException, IOException {
         jsonGenerator.setPrettyPrinter(new MinimalPrettyPrinter(""));
-        writeResultSetToJson(resultSet, jsonGenerator);
+        writeResultSetToJson(resultSet, jsonGenerator, bufferedStream);
+        jsonGenerator.flush();
+        bufferedStream.writeTo(terminalOutputStream);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLines.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLines.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.dataextractor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -12,12 +11,10 @@ import java.sql.SQLException;
 public class ExtractorJsonLines extends ExtractorJson {
 
     @Override
-    protected void write(ResultSet resultSet, JsonGenerator jsonGenerator, ByteArrayOutputStream bufferedStream)
+    protected void write(ResultSet resultSet, JsonGenerator jsonGenerator)
         throws SQLException, IOException {
         jsonGenerator.setPrettyPrinter(new MinimalPrettyPrinter(""));
-        writeResultSetToJson(resultSet, jsonGenerator, bufferedStream);
-        jsonGenerator.flush();
-        bufferedStream.writeTo(terminalOutputStream);
+        writeResultSetToJson(resultSet, jsonGenerator);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLines.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJsonLines.java
@@ -10,12 +10,14 @@ import java.sql.SQLException;
 
 public class ExtractorJsonLines extends ExtractorJson {
 
+    @Override
     protected void write(ResultSet resultSet, JsonGenerator jsonGenerator)
         throws SQLException, IOException {
         jsonGenerator.setPrettyPrinter(new MinimalPrettyPrinter(""));
         writeResultSetToJson(resultSet, jsonGenerator);
     }
 
+    @Override
     protected void writeEndObject(JsonGenerator jsonGenerator) throws IOException {
         jsonGenerator.writeEndObject();
         jsonGenerator.writeRaw("\n");

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/QueryExecutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/QueryExecutor.java
@@ -13,6 +13,8 @@ import java.sql.Statement;
 public class QueryExecutor implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(QueryExecutor.class);
+    private static final int QUERY_BATCH_SIZE = 200;
+
 
     private final String jdbcUrl;
     private final String user;
@@ -42,7 +44,7 @@ public class QueryExecutor implements AutoCloseable {
             this.connection.setAutoCommit(false);
             LOGGER.info("Executing sql...");
             this.statement = this.connection.createStatement();
-            this.statement.setFetchSize(50);
+            this.statement.setFetchSize(QUERY_BATCH_SIZE);
             long startTime = System.nanoTime();
             this.resultSet = this.statement.executeQuery(sql);
             long endTime = System.nanoTime();


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Large output can cause:

```
[main] WARN uk.gov.hmcts.reform.dataextractor.BlobOutputWriter - Could not close stream. Root cause is: The uncommitted block count cannot exceed the maximum limit of 100,000 blocks. Please see the cause for further information.
Exception in thread "main" java.lang.IllegalArgumentException: Self-suppression not permitted
	at java.base/java.lang.Throwable.addSuppressed(Throwable.java:1025)
	at uk.gov.hmcts.reform.dataextractor.ExtractorJson.apply(ExtractorJson.java:18)
	at uk.gov.hmcts.reform.dataextractor.DataExtractorAppl...
```



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```