### PR TITLE
Buffer output

### DIFF
--- a/charts/data-extractor-job/values.yaml
+++ b/charts/data-extractor-job/values.yaml
@@ -1,6 +1,8 @@
 job:
   image: hmcts.azurecr.io/hmcts/data-extractor:latest
   schedule: "0 2 * * *"
+  memoryLimits: '2048Mi'
+  cpuLimits: '2000m'
 global:
   job:
     kind: CronJob

--- a/src/integrationTest/resources/dataA1.csv
+++ b/src/integrationTest/resources/dataA1.csv
@@ -1,0 +1,2 @@
+"lastName",firstName","address"
+"A1S","Harry","a1Address"

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriter.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/BlobOutputWriter.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -29,6 +30,8 @@ public class BlobOutputWriter implements AutoCloseable {
     private static final String STORAGE_RESOURCE = "https://storage.azure.com/";
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
     private static final String CONNECTION_URI_TPL = "https://%s.blob.core.windows.net";
+
+    private static final int OUTPUT_BUFFER_SIZE = 100_000_000;
 
     private final String clientId;
     private final String accountName;
@@ -99,7 +102,7 @@ public class BlobOutputWriter implements AutoCloseable {
             container = client.getContainerReference(this.containerName);
             CloudBlockBlob blob = container.getBlockBlobReference(fileName);
             blob.getProperties().setContentType(outputType.getApplicationContent());
-            outputStream = blob.openOutputStream();
+            outputStream = new BufferedOutputStream(blob.openOutputStream(), OUTPUT_BUFFER_SIZE);
         } catch (URISyntaxException | StorageException e) {
             throw new WriterException(e);
         }

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorCsv.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorCsv.java
@@ -14,7 +14,7 @@ public class ExtractorCsv implements Extractor {
 
     public void apply(ResultSet resultSet, OutputStream outputStream) {
         try (CSVPrinter printer =
-            new CSVPrinter(new PrintWriter(outputStream, true), CSVFormat.DEFAULT.withHeader(resultSet))
+            new CSVPrinter(new PrintWriter(outputStream, false), CSVFormat.DEFAULT.withHeader(resultSet))
         ) {
             printer.printRecords(resultSet);
             printer.flush();

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/ExtractorJson.java
@@ -16,7 +16,9 @@ public class ExtractorJson implements Extractor {
     public void apply(ResultSet resultSet, OutputStream outputStream) {
         final ObjectMapper objectMapper = new ObjectMapper();
         try (JsonGenerator jsonGenerator =
-            objectMapper.getFactory().createGenerator(outputStream, JsonEncoding.UTF8)
+            objectMapper.getFactory()
+            .configure(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM, false)
+            .createGenerator(outputStream, JsonEncoding.UTF8)
         ) {
             writeResultSetToJson(resultSet, jsonGenerator);
             jsonGenerator.flush();

--- a/src/main/java/uk/gov/hmcts/reform/dataextractor/QueryExecutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/dataextractor/QueryExecutor.java
@@ -13,6 +13,7 @@ import java.sql.Statement;
 public class QueryExecutor implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(QueryExecutor.class);
+    private static final int QUERY_BATCH_SIZE = 200;
 
     private final String jdbcUrl;
     private final String user;
@@ -42,7 +43,7 @@ public class QueryExecutor implements AutoCloseable {
             this.connection.setAutoCommit(false);
             LOGGER.info("Executing sql...");
             this.statement = this.connection.createStatement();
-            this.statement.setFetchSize(50);
+            this.statement.setFetchSize(QUERY_BATCH_SIZE);
             long startTime = System.nanoTime();
             this.resultSet = this.statement.executeQuery(sql);
             long endTime = System.nanoTime();


### PR DESCRIPTION
### JIRA link (if applicable) ###

[AB#336]

### Change description ###

Large output can cause:

```
[main] WARN uk.gov.hmcts.reform.dataextractor.BlobOutputWriter - Could not close stream. Root cause is: The uncommitted block count cannot exceed the maximum limit of 100,000 blocks. Please see the cause for further information.
Exception in thread "main" java.lang.IllegalArgumentException: Self-suppression not permitted
	at java.base/java.lang.Throwable.addSuppressed(Throwable.java:1025)
	at uk.gov.hmcts.reform.dataextractor.ExtractorJson.apply(ExtractorJson.java:18)
	at uk.gov.hmcts.reform.dataextractor.DataExtractorAppl...
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
